### PR TITLE
Some debian package manager tweaks

### DIFF
--- a/csi/cmd/block/Dockerfile
+++ b/csi/cmd/block/Dockerfile
@@ -10,7 +10,7 @@ COPY nvme-cli-1.8.1  /nvme-cli-1.8.1
 
 # Install iscsi
 RUN apt-get update && \
-    apt-get -y install open-iscsi \
+    apt-get --no-install-recommends -y install open-iscsi \
     sysfsutils \
     sg3-utils \
     kmod \

--- a/csi/cmd/file/Dockerfile
+++ b/csi/cmd/file/Dockerfile
@@ -10,7 +10,7 @@ COPY nvme-cli-1.8.1  /nvme-cli-1.8.1
 
 # Install iscsi
 RUN apt-get update && \
-    apt-get -y install open-iscsi \
+    apt-get --no-install-recommends -y install open-iscsi \
     sysfsutils \
     kmod \
     ceph-common \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
