### PR TITLE
Add new soda-proxy which helps to communicate between side-cars and o…

### DIFF
--- a/csi-plug-n-play/sidecars/soda-proxy/Readme.md
+++ b/csi-plug-n-play/sidecars/soda-proxy/Readme.md
@@ -1,0 +1,37 @@
+## soda-proxy
+
+soda-proxy is a simple http server which helps to call the api's of SodaFoundation in a simpler way, it bypasses the authentication and directly helps to connect the osdsapi-server using the client provided by sodafoundation/api.
+
+### Build
+Please follow the below steps to build and run the proxy
+
+```go
+go get github.com/sodafoundation/nbp
+
+git checkout csipnp_dev 
+
+cd $GOPATH/src/github.com/sodafoundation/nbp/csi-plug-n-play/sidecars/soda-proxy
+
+go build cmd/proxy.go
+```
+
+Before running soda-proxy you need to export the below variables.
+
+```go
+
+export OPENSDS_ENDPOINT=http://{your_host_ip}:50040
+export OPENSDS_AUTH_STRATEGY=keystone
+export OS_AUTH_URL=http://{your_host_ip}/identity
+export OS_USERNAME=admin
+export OS_PASSWORD=opensds@123
+export OS_TENANT_NAME=admin
+export OS_PROJECT_NAME=admin
+export OS_USER_DOMAIN_ID=default
+```
+
+```go
+./proxy
+
+```
+
+By default soda-proxy runs on `0.0.0.0:50029`

--- a/csi-plug-n-play/sidecars/soda-proxy/Readme.md
+++ b/csi-plug-n-play/sidecars/soda-proxy/Readme.md
@@ -8,14 +8,12 @@ Please follow the below steps to build and run the proxy
 ```go
 go get github.com/sodafoundation/nbp
 
-git checkout csipnp_dev 
-
 cd $GOPATH/src/github.com/sodafoundation/nbp/csi-plug-n-play/sidecars/soda-proxy
 
 go build cmd/proxy.go
 ```
 
-Before running soda-proxy you need to export the below variables.
+Before running soda-proxy you need to export the below variables.(These are the same env variables which are required by osdsctl, for more reference you can see [this](https://github.com/sodafoundation/api/wiki/SODA-Projects-Cluster-Installation-through-Ansible#how-to-test-soda-projects-cluster))
 
 ```go
 

--- a/csi-plug-n-play/sidecars/soda-proxy/Readme.md
+++ b/csi-plug-n-play/sidecars/soda-proxy/Readme.md
@@ -13,7 +13,7 @@ cd $GOPATH/src/github.com/sodafoundation/nbp/csi-plug-n-play/sidecars/soda-proxy
 go build cmd/proxy.go
 ```
 
-Before running soda-proxy you need to export the below variables.(These are the same env variables which are required by osdsctl, for more reference you can see [this](https://github.com/sodafoundation/api/wiki/SODA-Projects-Cluster-Installation-through-Ansible#how-to-test-soda-projects-cluster))
+Before running soda-proxy you need to export the below variables.(These are the same env variables which are required by osdsctl, for more reference you can see [this](https://docs.sodafoundation.io/soda-gettingstarted/installation-using-ansible/#how-to-test-soda-projects-cluster))
 
 ```go
 

--- a/csi-plug-n-play/sidecars/soda-proxy/cmd/proxy.go
+++ b/csi-plug-n-play/sidecars/soda-proxy/cmd/proxy.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/gorilla/mux"
+	"github.com/sodafoundation/nbp/csi-plug-n-play/sidecars/soda-proxy/pkg/controller/profile"
+	"log"
+	"net/http"
+)
+
+func handleRequests() {
+	myRouter := mux.NewRouter().StrictSlash(true)
+	myRouter.HandleFunc("/getprofile/{id}", profile.GetProfile)
+	log.Fatal(http.ListenAndServe("0.0.0.0:50029", myRouter))
+}
+
+func main() {
+	handleRequests()
+}

--- a/csi-plug-n-play/sidecars/soda-proxy/pkg/controller/profile/profile.go
+++ b/csi-plug-n-play/sidecars/soda-proxy/pkg/controller/profile/profile.go
@@ -12,8 +12,8 @@ import (
 func GetProfile(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	key := vars["id"]
-	opensdsEndpoint, errr := os.LookupEnv("OPENSDS_ENDPOINT")
-	if !errr {
+	opensdsEndpoint, errLookUp := os.LookupEnv("OPENSDS_ENDPOINT")
+	if !errLookUp {
 		fmt.Println("No env variables found for endpoint, switching to default")
 		opensdsEndpoint = "http://127.0.0.1:50040"
 	}
@@ -23,7 +23,7 @@ func GetProfile(w http.ResponseWriter, r *http.Request) {
 	}
 	profile, errosds := client.GetProfile(key)
 	if errosds != nil {
-		fmt.Printf("Got error in GetProfile  : %s ===== %s", errosds.Error())
+		fmt.Printf("got error in GetProfile  : %s", errosds.Error())
 	}
 	json.NewEncoder(w).Encode(profile.CustomProperties)
 }

--- a/csi-plug-n-play/sidecars/soda-proxy/pkg/controller/profile/profile.go
+++ b/csi-plug-n-play/sidecars/soda-proxy/pkg/controller/profile/profile.go
@@ -1,0 +1,29 @@
+package profile
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/gorilla/mux"
+	"github.com/sodafoundation/nbp/client/opensds"
+	"net/http"
+	"os"
+)
+
+func GetProfile(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	key := vars["id"]
+	opensdsEndpoint, errr := os.LookupEnv("OPENSDS_ENDPOINT")
+	if !errr {
+		fmt.Println("No env variables found for endpoint, switching to default")
+		opensdsEndpoint = "http://127.0.0.1:50040"
+	}
+	client, err := opensds.GetClient(opensdsEndpoint, "keystone")
+	if client == nil || err != nil {
+		fmt.Printf("get opensds client failed: %v", err)
+	}
+	profile, errosds := client.GetProfile(key)
+	if errosds != nil {
+		fmt.Printf("Got error in GetProfile  : %s ===== %s", errosds.Error())
+	}
+	json.NewEncoder(w).Encode(profile.CustomProperties)
+}


### PR DESCRIPTION
…sdsapiserver

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
/kind new feature

**What this PR does / why we need it**:
In General side-cars needs to communicate with different api's of sodafoundation components, these side-cars are written as seprate entity and is unable to use the clients provided by sodafoundation/api to connect with apiserver.
These side-cars also has some restriction to alter their deployment and mount the cert files in the containers as the deployment is managed by vendor operators.
So to mitigate this challenge we have a `soda-proxy` which exposes the required api's needed by theses side-cars, these side-cars doesn't need auth to connect to these api's, where as `soda-proxy` internally uses the auth mechanism to connect the osdsapiserver.
By this we can enable a smooth communication between side-cars and soda components.

Currenly this PR just exposes profiles api but going forward this can exposes more api's which will be needed by these side-cars to bring the intelligence of sodafoundation to these side-cars.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #377 

**Test Report Added?**:
 /kind TESTED

**Test Report**:
Follow the readme to bring up the soda-proxy and then run the [example](https://github.com/sodafoundation/examples/tree/master/soda-csi-plug-n-play-poc).