### PR TITLE
Make csi-provisioner talk to soda apiserver via proxy

### DIFF
--- a/csi-plug-n-play/sidecars/soda-csi-provisioner/external-provisioner/pkg/controller/controller.go
+++ b/csi-plug-n-play/sidecars/soda-csi-provisioner/external-provisioner/pkg/controller/controller.go
@@ -445,7 +445,6 @@ func (cps CustomPropertiesSpec) GetDriverPreference() string {
 	for k, v := range cps {
 		if k == "driver" {
 			driverName = fmt.Sprintf("%v", v)
-			fmt.Println(driverName)
 		}
 	}
 	return driverName
@@ -460,9 +459,7 @@ func (p *csiProvisioner) ProvisionExt(options controller.ProvisionOptions) (*v1.
 	if err != nil {
 		klog.Fatalf("Error getting CSI driver name: %s", err)
 	}
-	klog.Infof("The Backend Driver Name is : %s ", backendDriverName)
-	klog.Infof("The provisioner.DriverName  is : %s ", p.driverName)
-	klog.Infof("The  options.StorageClass.Provisioner  is : %s ", options.StorageClass.Provisioner)
+	klog.Infof("The Backend Driver Name and provisioner name is : %s , %s", backendDriverName, p.driverName)
 
 	if options.StorageClass.Provisioner == "soda-csi" {
 		for k, v := range options.StorageClass.Parameters {
@@ -476,7 +473,7 @@ func (p *csiProvisioner) ProvisionExt(options controller.ProvisionOptions) (*v1.
 					data, _ := ioutil.ReadAll(response.Body)
 					var customProperties *CustomPropertiesSpec
 					json.Unmarshal(data, &customProperties)
-					klog.Infof("The profile name recieved in the storageClass is: %s",customProperties.GetDriverPreference())
+					klog.Infof("The profile name received in the storageClass is: %s", customProperties.GetDriverPreference())
 					if backendDriverName != customProperties.GetDriverPreference() {
 						return nil, controller.ProvisioningFinished, &controller.IgnoredError{
 							Reason: fmt.Sprintf("PVC doesnot match the current driver name : %s with expected %s",
@@ -487,19 +484,6 @@ func (p *csiProvisioner) ProvisionExt(options controller.ProvisionOptions) (*v1.
 			}
 		}
 	}
-	/*if options.StorageClass.Provisioner == "soda-csi-block" {
-		for k, v := range options.StorageClass.Parameters {
-			klog.Infof("The parameters in the StorageClass are  : %s ===== %s",k,v)
-			if k == "profile" {
-				if backendDriverName != v {
-					return nil, controller.ProvisioningFinished, &controller.IgnoredError{
-						Reason: fmt.Sprintf("PVC doesnot match the current driver name : %s with expected %s",
-							backendDriverName, v),
-					}
-				}
-			}
-		}
-	}*/
 
 	if options.PVC.Annotations[annStorageProvisioner] != p.driverName && options.PVC.Annotations[annMigratedTo] != p.driverName {
 		// The storage provisioner annotation may not equal driver name but the

--- a/csi-plug-n-play/sidecars/soda-csi-provisioner/external-provisioner/pkg/controller/controller.go
+++ b/csi-plug-n-play/sidecars/soda-csi-provisioner/external-provisioner/pkg/controller/controller.go
@@ -20,6 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
 	"math"
 	"os"
 	"strings"
@@ -182,8 +187,7 @@ var (
 		secretNameKey:      prefixedControllerExpandSecretNameKey,
 		secretNamespaceKey: prefixedControllerExpandSecretNamespaceKey,
 	}
-	operationTimeout     =  10*time.Second
-
+	operationTimeout = 10 * time.Second
 )
 
 // ProvisionerCSITranslator contains the set of CSI Translation functionality
@@ -424,6 +428,28 @@ func (p *csiProvisioner) Provision(options controller.ProvisionOptions) (*v1.Per
 	return pv, err
 }
 
+type CustomPropertiesSpec map[string]interface{}
+
+func (cps CustomPropertiesSpec) IsEmpty() bool {
+	if nil == cps {
+		return true
+	}
+	return false
+}
+
+func (cps CustomPropertiesSpec) GetDriverPreference() string {
+	var driverName string
+	if cps.IsEmpty() {
+		return "NoDriverFound"
+	}
+	for k, v := range cps {
+		if k == "driver" {
+			driverName = fmt.Sprintf("%v", v)
+			fmt.Println(driverName)
+		}
+	}
+	return driverName
+}
 func (p *csiProvisioner) ProvisionExt(options controller.ProvisionOptions) (*v1.PersistentVolume, controller.ProvisioningState, error) {
 	if options.StorageClass == nil {
 		return nil, controller.ProvisioningFinished, errors.New("storage class was nil")
@@ -434,36 +460,34 @@ func (p *csiProvisioner) ProvisionExt(options controller.ProvisionOptions) (*v1.
 	if err != nil {
 		klog.Fatalf("Error getting CSI driver name: %s", err)
 	}
-	klog.Infof("The Backend Driver Name is : %s ",backendDriverName)
-	klog.Infof("The provisioner.DriverName  is : %s ",p.driverName)
+	klog.Infof("The Backend Driver Name is : %s ", backendDriverName)
+	klog.Infof("The provisioner.DriverName  is : %s ", p.driverName)
+	klog.Infof("The  options.StorageClass.Provisioner  is : %s ", options.StorageClass.Provisioner)
 
-	//TODO Make this code work with SODA API-Server (Issue is with Grpc version, soda uses v1.29.1 whereas csi-provisioner uses v1.26.0
-	/*client, err := opensds.GetClient("192.168.20.61:50040", "noauth")
-	if client == nil || err != nil {
-		klog.Errorf("get opensds client failed: %v", err)
-
-	}
-
-	if options.StorageClass.Provisioner == "soda-csi-block" {
+	if options.StorageClass.Provisioner == "soda-csi" {
 		for k, v := range options.StorageClass.Parameters {
-			klog.Infof("The parameters in the StorageClass are  : %s ===== %s",k,v)
+			klog.Infof("The parameters in the StorageClass are  : %s ===== %s", k, v)
 			if k == "profile" {
 
-				profile, errosds := client.GetProfile(v)
-				if errosds != nil {
-					klog.Infof("Got error in GetProfile  : %s ===== %s", errosds.Error())
-				}
-				klog.Infof("The profile name recieved in the storageClass is: %s ===== %s",profile.Name)
-				if backendDriverName != profile.Name {
-					return nil, controller.ProvisioningFinished, &controller.IgnoredError{
-						Reason: fmt.Sprintf("PVC doesnot match the current driver name : %s with expected %s",
-							p.driverName, profile.Name),
+				response, err := http.Get("http://soda-proxy:50029/getprofile/" + v)
+				if err != nil {
+					klog.Infof("Got error in GetProfile  : %s ===== %s", err.Error())
+				} else {
+					data, _ := ioutil.ReadAll(response.Body)
+					var customProperties *CustomPropertiesSpec
+					json.Unmarshal(data, &customProperties)
+					klog.Infof("The profile name recieved in the storageClass is: %s",customProperties.GetDriverPreference())
+					if backendDriverName != customProperties.GetDriverPreference() {
+						return nil, controller.ProvisioningFinished, &controller.IgnoredError{
+							Reason: fmt.Sprintf("PVC doesnot match the current driver name : %s with expected %s",
+								p.driverName, "profile.Name"),
+						}
 					}
 				}
 			}
 		}
-	}*/
-	if options.StorageClass.Provisioner == "soda-csi-block" {
+	}
+	/*if options.StorageClass.Provisioner == "soda-csi-block" {
 		for k, v := range options.StorageClass.Parameters {
 			klog.Infof("The parameters in the StorageClass are  : %s ===== %s",k,v)
 			if k == "profile" {
@@ -475,8 +499,7 @@ func (p *csiProvisioner) ProvisionExt(options controller.ProvisionOptions) (*v1.
 				}
 			}
 		}
-	}
-
+	}*/
 
 	if options.PVC.Annotations[annStorageProvisioner] != p.driverName && options.PVC.Annotations[annMigratedTo] != p.driverName {
 		// The storage provisioner annotation may not equal driver name but the


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
 /kind enhancement

**What this PR does / why we need it**:
This PR enables soda-csi-provisioner to talk to soda-proxy to get the details of the profile using profileID given by user in StorageClass.
This will help soda-csi-provisioner to dynamically choose the heterogeneous storages as per the need and availability.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #377 

**Test Report Added?**:
 /kind TESTED


**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
Follow the readme to bring up the soda-proxy and then run the [example](https://github.com/sodafoundation/examples/tree/master/soda-csi-plug-n-play-poc).
**Special notes for your reviewer**:
